### PR TITLE
add project client docs

### DIFF
--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -26,6 +26,7 @@
   - [`invite`](#invite)
 
     - [`invite.create`](#invitecreate)
+    - [`invite.get`](#inviteget)
     - [`invite.getMany`](#invitegetmany`)
 
 ## Description
@@ -186,17 +187,36 @@ Interface for managing project invites.
 
 #### `invite.create`
 
-`(id: string, role: ProjectRole) => Promise<void>`
+`(id: string, role: ProjectRole) => Promise<CreatedInvite>`
 
-Invite a peer to join the project. Note that this adheres to a “fire-and-forget” strategy and should resolve when the invite is successfully _sent_. If you need to subscribe to when the invite is either accepted or declined, use the `invite-accepted` or `invite-declined` events, respectively.
+Invite a peer to join the project. Note that this adheres to a “fire-and-forget” strategy and should resolve with the created invite when the invite is successfully _dispatched_. If you need to subscribe to when the invite is either accepted or declined, use the `invite-accepted` or `invite-declined` events, respectively.
 
 ```ts
-await client.$project.invite.create("some-peer-id", "member");
+const invite = await client.$project.invite.create("some-peer-id", "member");
 ```
 
 **_TODO: is fire-and-forget okay for this?_**
 
 **_TODO: anything besides role that needs to be added as param?_**
+
+### `invite.get`
+
+`(id: string) => Promie<CreatedInvite | null>`
+
+Get an invite with `id` that has been created.
+
+```ts
+// First create an invite
+const createdInvite = await client.$project.invite.create(
+  "some-peer-id",
+  "member"
+);
+
+// Then fetch the invite
+const invite = await client.$project.invite.get(createdInvite.id);
+
+console.assert(invite.id === createdInvite.id);
+```
 
 #### `invite.getMany`
 

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -14,14 +14,6 @@
 
   - [`info`](#info)
 
-    - [`info.get`](#infoget)
-    - [`info.update`](#infoupdate)
-
-  - [`invite`](#invite)
-
-    - [`invite.create`](#invitecreate)
-    - [`invite.getMany`](#invitegetmany`)
-
   - [`member`](#member)
 
     - [`member.get`](#memberget)
@@ -30,7 +22,13 @@
     - [`member.remove`](#memberremove)
     - [`member.update`](#memberupdate)
 
+  - [`invite`](#invite)
+
+    - [`invite.create`](#invitecreate)
+    - [`invite.getMany`](#invitegetmany`)
+
 - [Events](#events)
+
   - [`'invite:accepted'`](#inviteaccepted)
   - [`'invite:declined'`](#invitedeclined)
 
@@ -80,31 +78,13 @@ type ProjectMember = {
 
 ### `info`
 
-Interface for project-specific information.
-
-#### `info.get`
-
 `() => Promise<Project>`
 
 Get information about the current project.
 
 ```ts
-const project = await mapeo.$project.info.get();
+const projectInfo = await mapeo.$project.info();
 ```
-
-#### `info.update`
-
-`(info: {}) => Promise<Project>`
-
-Update information about the project. Throws if caller does not have the proper permissions.
-
-```ts
-const project = await mapeo.$project.info.get()
-
-const updatedProject = await mapeo.$project.info.update({...})
-```
-
-**_TODO: What project info can be updated?_**
 
 ### `member`
 

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -127,20 +127,18 @@ const members = await client.$project.member.getMany();
 
 #### `member.add`
 
-`(id: string, info: {}) => Promise<ProjectMember>`
+`(id: string, info: { name?: string, role: ProjectRole }) => Promise<ProjectMember>`
 
 Add a member to the project. Throws if the member already exists or if the caller does not have the proper permissions. Resolves with the created member.
 
 ```ts
-const memberPublicKey = 'abc123'
-const memberInfo = {...}
-
-const member = await client.$project.member.add(memberPublicKey, memberInfo)
+const member = await client.$project.member.add("abc123", {
+  name: "andrew",
+  role: "member",
+});
 ```
 
 **_TODO: consolidate to single object param?_**
-
-**_TODO: what’s needed in `info`?_**
 
 **_TODO: should we not throw if member already exists?_**
 
@@ -160,26 +158,29 @@ await client.$project.member.remove(member.id)
 
 **_TODO: should we not throw if member not found?_**
 
-**_TODO: should we have a batch method for this?_**
-
 #### `member.update`
 
-`(id: string, info: { role: ProjectRole }) => Promise<ProjectMember>`
+`(id: string, info: { name?: string | null, role?: ProjectRole }) => Promise<ProjectMember>`
 
-Update info about a member. Throws if the member does not exist or if the caller does not have the proper privileges.
+Update info about a member. Update is done by merging `info` as opposed to setting. Throws if the member does not exist or if the caller does not have the proper permissions.
 
 ```ts
 // Add the member
-const member = await client.$project.member.add('abc123', {...})
+const member = await client.$project.member.add("abc123", {
+  name: "andrew",
+  role: "member",
+});
 
-// Update the member
-const updatedMember = await client.$project.member.update(member.id, {
-  ...member,
-  // Any relevant properties you want to update
-})
+// Update the member's role
+const memberWithUpdatedRole = await client.$project.member.update(member.id, {
+  role: "coordinator",
+});
+
+// Remove the member's name by explicitly using null
+const memberWithUpdatedName = await client.$project.member.update(member.id, {
+  name: null,
+});
 ```
-
-**_TODO: should this be limited to just updating role, or are there other things that could be updated?_**
 
 ### `invite`
 

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -91,7 +91,7 @@ Interface for managing a project's members.
 
 #### `member.get`
 
-`(id: string) => Promise<ProjectMember>`
+`(id: string) => Promise<ProjectMember | null>`
 
 Get information about a project member (including yourself).
 

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -77,7 +77,7 @@ type ProjectMember = {
 Get information about the current project.
 
 ```ts
-const projectInfo = await mapeo.$project.info();
+const projectInfo = await client.$project.info();
 ```
 
 ### `member`
@@ -91,7 +91,7 @@ Interface for managing a project's members.
 Get information about a project member (including yourself).
 
 ```ts
-const member = await mapeo.$project.member.get("abc123");
+const member = await client.$project.member.get("abc123");
 ```
 
 **_TODO: how do we get ourself?_**
@@ -103,7 +103,7 @@ const member = await mapeo.$project.member.get("abc123");
 Get all project members and information about each (including yourself).
 
 ```ts
-const members = await mapeo.$project.member.getMany();
+const members = await client.$project.member.getMany();
 ```
 
 **_TODO: any `opts` needed?_**
@@ -118,7 +118,7 @@ Add a member to the project. Throws if the member already exists or if the calle
 const memberPublicKey = 'abc123'
 const memberInfo = {...}
 
-const member = await mapeo.$project.member.add(memberPublicKey, memberInfo)
+const member = await client.$project.member.add(memberPublicKey, memberInfo)
 ```
 
 **_TODO: consolidate to single object param?_**
@@ -135,10 +135,10 @@ Remove a member from the project. Throws if the member does not exist or if the 
 
 ```ts
 // Add the member
-const member = await mapeo.$project.member.add('abc123', {...})
+const member = await client.$project.member.add('abc123', {...})
 
 // Nevermind, time to remove the member
-await mapeo.$project.member.remove(member.id)
+await client.$project.member.remove(member.id)
 ```
 
 **_TODO: should we not throw if member not found?_**
@@ -153,10 +153,10 @@ Update info about a member. Throws if the member does not exist or if the caller
 
 ```ts
 // Add the member
-const member = await mapeo.$project.member.add('abc123', {...})
+const member = await client.$project.member.add('abc123', {...})
 
 // Update the member
-const updatedMember = await mapeo.$project.member.update(member.id, {
+const updatedMember = await client.$project.member.update(member.id, {
   ...member,
   // Any relevant properties you want to update
 })
@@ -175,7 +175,7 @@ Interface for managing project invites.
 Invite a peer to join the project. Note that this adheres to a “fire-and-forget” strategy and should resolve when the invite is successfully _sent_. If you need to subscribe to when the invite is either accepted or declined, add an event listener for the `invite:accepted` or `invite:declined` events, respectively.
 
 ```ts
-await mapeo.$project.invite.create("some-peer-id", "member");
+await client.$project.invite.create("some-peer-id", "member");
 ```
 
 **_TODO: is fire-and-forget okay for this?_**
@@ -190,11 +190,11 @@ Get invites that have been created. Can use `opts` to filter the returned result
 
 ```ts
 // Invite some peers
-await mapeo.$project.invite.create("peer-a", "coordinator");
-await mapeo.$project.invite.create("peer-b", "member");
-await mapeo.$project.invite.create("peer-c", "member");
+await client.$project.invite.create("peer-a", "coordinator");
+await client.$project.invite.create("peer-b", "member");
+await client.$project.invite.create("peer-c", "member");
 
-const invites = await mapeo.$project.invite.getMany();
+const invites = await client.$project.invite.getMany();
 
 // Assuming none of them have responded yet, outputs 3
 console.log(invites.length);

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -34,7 +34,7 @@
 
 ## Description
 
-Exposes an interface for managing a project's information, members, and invites.
+Exposes an interface for managing a projects' members and invites.
 
 ## Types
 

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -27,11 +27,6 @@
     - [`invite.create`](#invitecreate)
     - [`invite.getMany`](#invitegetmany`)
 
-- [Events](#events)
-
-  - [`'invite:accepted'`](#inviteaccepted)
-  - [`'invite:declined'`](#invitedeclined)
-
 ## Description
 
 Exposes an interface for managing a projects' members and invites.
@@ -204,36 +199,3 @@ const invites = await mapeo.$project.invite.getMany();
 // Assuming none of them have responded yet, outputs 3
 console.log(invites.length);
 ```
-
-## Events
-
-### `'invite:accepted'`
-
-`(id: string, info: { role: ProjectRole }) => void`
-
-Emits when an invited peer has accepted an invitation to join the project. `info` represents information about the invitation that was sent, such as the role.
-
-```ts
-mapeo.$project.on("invite:accepted", async (id, info) => {
-  console.log(`${id} accepted invite to be ${info.role}`);
-
-  // Should be able to retrieve the project member now
-  const member = await mapeo.$project.member.get(id);
-});
-```
-
-**_TODO: should it be possible to get the member at this point, or should this be responsible for explicitly adding the member to the project? i.e. calling `addMember` in the callback body?_**
-
-### `'invite:declined'`
-
-`(id: string, info: { role: ProjectRole }) => void`
-
-Listen to events that are emitted when an invited peer has declined an invitation to join the project. `info` represents information about the invitation that was sent, such as the role.
-
-```ts
-mapeo.$project.on("invite:declined", (id, info) => {
-  console.log(`${id} declined invite to be ${info.role}`);
-});
-```
-
-**_TODO: what other things should be included in `info`?_**

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -9,6 +9,7 @@
   - [`Project`](#project)
   - [`ProjectRole`](#projectrole)
   - [`ProjectMember`](#projectmember)
+  - [`CreatedInvite`](#createdinvite)
 
 - [Methods](#methods)
 
@@ -35,7 +36,7 @@ Exposes an interface for managing a projects' members and invites.
 
 ### `Project`
 
-Information about the current project. Could potentially look like:
+Information about the current project.
 
 ```ts
 type Project = {
@@ -48,7 +49,7 @@ type Project = {
 
 ### `ProjectRole`
 
-Information about the project role for a member. Could potentially look like:
+Information about the project role for a member.
 
 ```ts
 type ProjectRole = "creator" | "coordinator" | "member";
@@ -58,13 +59,28 @@ type ProjectRole = "creator" | "coordinator" | "member";
 
 ### `ProjectMember`
 
-A member that is part of the project. Could potentially look like:
+A member that is part of the project.
 
 ```ts
 type ProjectMember = {
   id: string;
-  name?: string;
+  name: string | null;
   role: ProjectRole;
+};
+```
+
+### `CreatedInvite`
+
+Information about an invite that has been created.
+
+```ts
+type CreatedInvite = {
+  id: string;
+  to: {
+    id: string;
+  };
+  role: ProjectRole;
+  status: "pending" | "accepted" | "declined" | "rescinded";
 };
 ```
 
@@ -172,7 +188,7 @@ Interface for managing project invites.
 
 `(id: string, role: ProjectRole) => Promise<void>`
 
-Invite a peer to join the project. Note that this adheres to a “fire-and-forget” strategy and should resolve when the invite is successfully _sent_. If you need to subscribe to when the invite is either accepted or declined, add an event listener for the `invite:accepted` or `invite:declined` events, respectively.
+Invite a peer to join the project. Note that this adheres to a “fire-and-forget” strategy and should resolve when the invite is successfully _sent_. If you need to subscribe to when the invite is either accepted or declined, use the `invite-accepted` or `invite-declined` events, respectively.
 
 ```ts
 await client.$project.invite.create("some-peer-id", "member");
@@ -184,7 +200,7 @@ await client.$project.invite.create("some-peer-id", "member");
 
 #### `invite.getMany`
 
-`(opts?: { pending?: boolean, accepted?: boolean, declined?: boolean }) => Promise<Invite[]>`
+`(opts?: { pending?: boolean, accepted?: boolean, declined?: boolean, rescinded?: boolean }) => Promise<CreatedInvite[]>`
 
 Get invites that have been created. Can use `opts` to filter the returned results based on their status. All opts are `true` by default.
 
@@ -196,6 +212,5 @@ await client.$project.invite.create("peer-c", "member");
 
 const invites = await client.$project.invite.getMany();
 
-// Assuming none of them have responded yet, outputs 3
-console.log(invites.length);
+console.log(invites.length); // logs 3
 ```

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -46,18 +46,17 @@ Information about the current project. Could potentially look like:
 type Project = {
   id: string;
   name: string;
-  config: Config;
 };
 ```
 
-**_TODO: define `Config`_**
+**_TODO: what other fields are relevant?_**
 
 ### `ProjectRole`
 
 Information about the project role for a member. Could potentially look like:
 
 ```ts
-type ProjectRole = "project-creator" | "coordinator" | "member";
+type ProjectRole = "creator" | "coordinator" | "member";
 ```
 
 **_TODO: should `non-member` be included here?_**

--- a/client-docs/project.md
+++ b/client-docs/project.md
@@ -1,0 +1,260 @@
+# Project API
+
+## Table of Contents
+
+- [Description](#description)
+
+- [Types](#types)
+
+  - [`Project`](#project)
+  - [`ProjectRole`](#projectrole)
+  - [`ProjectMember`](#projectmember)
+
+- [Methods](#methods)
+
+  - [`info`](#info)
+
+    - [`info.get`](#infoget)
+    - [`info.update`](#infoupdate)
+
+  - [`invite`](#invite)
+
+    - [`invite.create`](#invitecreate)
+    - [`invite.getMany`](#invitegetmany`)
+
+  - [`member`](#member)
+
+    - [`member.get`](#memberget)
+    - [`member.getMany`](#membergetmany)
+    - [`member.add`](#memberadd)
+    - [`member.remove`](#memberremove)
+    - [`member.update`](#memberupdate)
+
+- [Events](#events)
+  - [`'invite:accepted'`](#inviteaccepted)
+  - [`'invite:declined'`](#invitedeclined)
+
+## Description
+
+Exposes an interface for managing a project's information, members, and invites.
+
+## Types
+
+### `Project`
+
+Information about the current project. Could potentially look like:
+
+```ts
+type Project = {
+  id: string;
+  name: string;
+  config: Config;
+};
+```
+
+**_TODO: define `Config`_**
+
+### `ProjectRole`
+
+Information about the project role for a member. Could potentially look like:
+
+```ts
+type ProjectRole = "project-creator" | "coordinator" | "member";
+```
+
+**_TODO: should `non-member` be included here?_**
+
+### `ProjectMember`
+
+A member that is part of the project. Could potentially look like:
+
+```ts
+type ProjectMember = {
+  id: string;
+  name?: string;
+  role: ProjectRole;
+};
+```
+
+## Methods
+
+### `info`
+
+Interface for project-specific information.
+
+#### `info.get`
+
+`() => Promise<Project>`
+
+Get information about the current project.
+
+```ts
+const project = await mapeo.$project.info.get();
+```
+
+#### `info.update`
+
+`(info: {}) => Promise<Project>`
+
+Update information about the project. Throws if caller does not have the proper permissions.
+
+```ts
+const project = await mapeo.$project.info.get()
+
+const updatedProject = await mapeo.$project.info.update({...})
+```
+
+**_TODO: What project info can be updated?_**
+
+### `member`
+
+Interface for managing a project's members.
+
+#### `member.get`
+
+`(id: string) => Promise<ProjectMember>`
+
+Get information about a project member (including yourself).
+
+```ts
+const member = await mapeo.$project.member.get("abc123");
+```
+
+**_TODO: how do we get ourself?_**
+
+#### `member.getMany`
+
+`(opts: {}) => Promise<ProjectMember[]>`
+
+Get all project members and information about each (including yourself).
+
+```ts
+const members = await mapeo.$project.member.getMany();
+```
+
+**_TODO: any `opts` needed?_**
+
+#### `member.add`
+
+`(id: string, info: {}) => Promise<ProjectMember>`
+
+Add a member to the project. Throws if the member already exists or if the caller does not have the proper permissions. Resolves with the created member.
+
+```ts
+const memberPublicKey = 'abc123'
+const memberInfo = {...}
+
+const member = await mapeo.$project.member.add(memberPublicKey, memberInfo)
+```
+
+**_TODO: consolidate to single object param?_**
+
+**_TODO: what’s needed in `info`?_**
+
+**_TODO: should we not throw if member already exists?_**
+
+#### `member.remove`
+
+`(id: string) => Promise<void>`
+
+Remove a member from the project. Throws if the member does not exist or if the caller does not have the proper permissions.
+
+```ts
+// Add the member
+const member = await mapeo.$project.member.add('abc123', {...})
+
+// Nevermind, time to remove the member
+await mapeo.$project.member.remove(member.id)
+```
+
+**_TODO: should we not throw if member not found?_**
+
+**_TODO: should we have a batch method for this?_**
+
+#### `member.update`
+
+`(id: string, info: { role: ProjectRole }) => Promise<ProjectMember>`
+
+Update info about a member. Throws if the member does not exist or if the caller does not have the proper privileges.
+
+```ts
+// Add the member
+const member = await mapeo.$project.member.add('abc123', {...})
+
+// Update the member
+const updatedMember = await mapeo.$project.member.update(member.id, {
+  ...member,
+  // Any relevant properties you want to update
+})
+```
+
+**_TODO: should this be limited to just updating role, or are there other things that could be updated?_**
+
+### `invite`
+
+Interface for managing project invites.
+
+#### `invite.create`
+
+`(id: string, role: ProjectRole) => Promise<void>`
+
+Invite a peer to join the project. Note that this adheres to a “fire-and-forget” strategy and should resolve when the invite is successfully _sent_. If you need to subscribe to when the invite is either accepted or declined, add an event listener for the `invite:accepted` or `invite:declined` events, respectively.
+
+```ts
+await mapeo.$project.invite.create("some-peer-id", "member");
+```
+
+**_TODO: is fire-and-forget okay for this?_**
+
+**_TODO: anything besides role that needs to be added as param?_**
+
+#### `invite.getMany`
+
+`(opts?: { pending?: boolean, accepted?: boolean, declined?: boolean }) => Promise<Invite[]>`
+
+Get invites that have been created. Can use `opts` to filter the returned results based on their status. All opts are `true` by default.
+
+```ts
+// Invite some peers
+await mapeo.$project.invite.create("peer-a", "coordinator");
+await mapeo.$project.invite.create("peer-b", "member");
+await mapeo.$project.invite.create("peer-c", "member");
+
+const invites = await mapeo.$project.invite.getMany();
+
+// Assuming none of them have responded yet, outputs 3
+console.log(invites.length);
+```
+
+## Events
+
+### `'invite:accepted'`
+
+`(id: string, info: { role: ProjectRole }) => void`
+
+Emits when an invited peer has accepted an invitation to join the project. `info` represents information about the invitation that was sent, such as the role.
+
+```ts
+mapeo.$project.on("invite:accepted", async (id, info) => {
+  console.log(`${id} accepted invite to be ${info.role}`);
+
+  // Should be able to retrieve the project member now
+  const member = await mapeo.$project.member.get(id);
+});
+```
+
+**_TODO: should it be possible to get the member at this point, or should this be responsible for explicitly adding the member to the project? i.e. calling `addMember` in the callback body?_**
+
+### `'invite:declined'`
+
+`(id: string, info: { role: ProjectRole }) => void`
+
+Listen to events that are emitted when an invited peer has declined an invitation to join the project. `info` represents information about the invitation that was sent, such as the role.
+
+```ts
+mapeo.$project.on("invite:declined", (id, info) => {
+  console.log(`${id} declined invite to be ${info.role}`);
+});
+```
+
+**_TODO: what other things should be included in `info`?_**


### PR DESCRIPTION
Relevant issues:

- https://github.com/digidem/mapeo-core-next/issues/74
- https://github.com/digidem/mapeo-core-next/issues/98

TODOs:

- Consider removing `$` prefix for namespace
- Many levels of nesting okay?
- Is it possible to delete an invite?
  - maybe rescinding could be an option?
- ~Should `info` namespace live in project management api?~ Moved to #8 
  - ~or maybe at least `info.update`?~
- Should `invite` be its own namespace? e.g. `mapeo.$invite`
- ~remove events spec~