### PR TITLE
add client docs for projects management

### DIFF
--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -51,7 +51,7 @@ type Project = {
 Information about the project role for a member. Could potentially look like:
 
 ```ts
-type ProjectRole = "project-creator" | "coordinator" | "member";
+type ProjectRole = "creator" | "coordinator" | "member";
 ```
 
 **_TODO: should `non-member` be included here?_**

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -72,7 +72,7 @@ type ProjectMember = {
 
 ### `get`
 
-`(id: string) => Promise<Project[]>`
+`(id: string) => Promise<Project | null>`
 
 Get information about a project with the specified `id`.
 

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -106,26 +106,30 @@ const deletedProject = await client.$projectsManagement.delete(project.id);
 
 #### `invite.accept`
 
-`(id: string, params: { projectKey: string }) => Promise<void>`
+`(id: string, params: {}) => Promise<void>`
 
 Accept an invite received from another peer.
 
 ```ts
 client.on('invite-received', (invite) => {
   // In reality, probably would perform logic to check it
-  client.$projectsManagement.invite.accept(invite.id, { projectKey: ... })
+  client.$projectsManagement.invite.accept(invite.id, { ... })
 })
 ```
 
+**_TODO: What does `params` look like?_**
+
 #### `invite.decline`
 
-`(id: string, params: { projectKey: string }) => Promise<void>`
+`(id: string, params: {}) => Promise<void>`
 
 Decline an invite received from another peer.
 
 ```ts
 client.on('invite-received', (invite) => {
   // In reality, probably would perform logic to check it
-  client.$projectsManagement.invite.decline(invite.id, { projectKey: ... })
+  client.$projectsManagement.invite.decline(invite.id, { ... })
 })
 ```
+
+**_TODO: What does `params` look like?_**

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -68,19 +68,17 @@ const projects = await client.$projectsManagement.getMany();
 
 ### `create`
 
-`(opts?: {}) => Promise<Project>`
+`(opts: { name: string }) => Promise<Project>`
 
 Create a project.
 
 ```ts
-const project = await client.$projectsManagement.create({...});
+const project = await client.$projectsManagement.create({ name: "mapeo" });
 ```
-
-**_TODO: What does `opts` look like?_**
 
 ### `update`
 
-`(projectId: string, newInfo: {}) => Promise<Project>`
+`(projectId: string, newInfo: { name: string }) => Promise<Project>`
 
 Update a project's information. Throws if caller does not have the proper permissions or if the project does not exist.
 
@@ -89,8 +87,6 @@ const project = await client.$projectsManagement.create({...});
 
 const updatedProject = await client.$projectsManagement.update(project.id, {...});
 ```
-
-**_TODO: What does `newInfo` look like?_**
 
 ### `delete`
 
@@ -110,30 +106,26 @@ const deletedProject = await client.$projectsManagement.delete(project.id);
 
 #### `invite.accept`
 
-`(id: string, params: {}) => Promise<void>`
+`(id: string, params: { projectKey: string }) => Promise<void>`
 
 Accept an invite received from another peer.
 
 ```ts
 client.on('invite-received', (invite) => {
   // In reality, probably would perform logic to check it
-  client.$projectsManagement.invite.accept(invite.id, {...})
+  client.$projectsManagement.invite.accept(invite.id, { projectKey: ... })
 })
 ```
 
-**_TODO: What does `params` look like?_**
-
 #### `invite.decline`
 
-`(id: string, params: {}) => Promise<void>`
+`(id: string, params: { projectKey: string }) => Promise<void>`
 
 Decline an invite received from another peer.
 
 ```ts
 client.on('invite-received', (invite) => {
   // In reality, probably would perform logic to check it
-  client.$projectsManagement.invite.decline(invite.id, {...})
+  client.$projectsManagement.invite.decline(invite.id, { projectKey: ... })
 })
 ```
-
-**_TODO: What does `params` look like?_**

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -7,8 +7,6 @@
 - [Types](#types)
 
   - [`Project`](#project)
-  - [`ProjectRole`](#projectrole)
-  - [`ProjectMember`](#projectmember)
 
 - [Methods](#methods)
 
@@ -41,28 +39,6 @@ type Project = {
 ```
 
 **_TODO: what other fields are relevant?_**
-
-### `ProjectRole`
-
-Information about the project role for a member. Could potentially look like:
-
-```ts
-type ProjectRole = "creator" | "coordinator" | "member";
-```
-
-**_TODO: should `non-member` be included here?_**
-
-### `ProjectMember`
-
-A member that is part of the project. Could potentially look like:
-
-```ts
-type ProjectMember = {
-  id: string;
-  name?: string;
-  role: ProjectRole;
-};
-```
 
 ## Methods
 
@@ -106,7 +82,7 @@ const project = await client.$projectsManagement.create({...});
 
 `(projectId: string, newInfo: {}) => Promise<Project>`
 
-Update a project's information. Throws if caller does not have the proper permissions.
+Update a project's information. Throws if caller does not have the proper permissions or if the project does not exist.
 
 ```ts
 const project = await client.$projectsManagement.create({...});
@@ -120,7 +96,7 @@ const updatedProject = await client.$projectsManagement.update(project.id, {...}
 
 `(id: string) => Promise<Project>`
 
-Delete a project with the specified `id`. Throws if caller does not have the proper permissions.
+Delete a project with the specified `id`. Throws if caller does not have the proper permissions or if the project does not exist.
 
 ```ts
 const project = await client.$projectsManagement.create();
@@ -139,15 +115,13 @@ const deletedProject = await client.$projectsManagement.delete(project.id);
 Accept an invite received from another peer.
 
 ```ts
-client.$projectsManagement.on('invite:received', (info) => {
+client.on('invite-received', (invite) => {
   // In reality, probably would perform logic to check it
-  client.$projectsManagement.invite.accept(info.id, {...})
+  client.$projectsManagement.invite.accept(invite.id, {...})
 })
 ```
 
 **_TODO: What does `params` look like?_**
-
-**_TODO: Does this belong in this API?_**
 
 #### `invite.decline`
 
@@ -156,9 +130,9 @@ client.$projectsManagement.on('invite:received', (info) => {
 Decline an invite received from another peer.
 
 ```ts
-client.$projectsManagement.on('invite:received', (info) => {
+client.on('invite-received', (invite) => {
   // In reality, probably would perform logic to check it
-  client.$projectsManagement.invite.decline(info.id, {...})
+  client.$projectsManagement.invite.decline(invite.id, {...})
 })
 ```
 

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -41,11 +41,10 @@ Information about the current project. Could potentially look like:
 type Project = {
   id: string;
   name: string;
-  config: Config;
 };
 ```
 
-**_TODO: define `Config`_**
+**_TODO: what other fields are relevant?_**
 
 ### `ProjectRole`
 

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -12,7 +12,8 @@
 
 - [Methods](#methods)
 
-  - [`getAll`](#getall)
+  - [`get`](#get)
+  - [`getMany`](#getmany)
   - [`create`](#create)
   - [`update`](#update)
   - [`delete`](#delete)
@@ -70,15 +71,29 @@ type ProjectMember = {
 
 ## Methods
 
-### `getAll`
+### `get`
 
-`() => Promise<Project[]>`
+`(id: string) => Promise<Project[]>`
+
+Get information about a project with the specified `id`.
+
+```ts
+const projects = await mapeo.$projectsManagement.get("abc123");
+```
+
+### `getMany`
+
+`(opts?: {}) => Promise<Project[]>`
 
 Get all projects.
 
 ```ts
-const projects = await mapeo.$projectsManagement.getAll();
+const projects = await mapeo.$projectsManagement.getMany();
 ```
+
+**_TODO: What does `opts` look like?_**
+
+**_TODO: Should return type be different?_**
 
 ### `create`
 

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -73,7 +73,7 @@ type ProjectMember = {
 Get information about a project with the specified `id`.
 
 ```ts
-const projects = await mapeo.$projectsManagement.get("abc123");
+const projects = await client.$projectsManagement.get("abc123");
 ```
 
 ### `getMany`
@@ -83,7 +83,7 @@ const projects = await mapeo.$projectsManagement.get("abc123");
 Get all projects.
 
 ```ts
-const projects = await mapeo.$projectsManagement.getMany();
+const projects = await client.$projectsManagement.getMany();
 ```
 
 **_TODO: What does `opts` look like?_**
@@ -97,7 +97,7 @@ const projects = await mapeo.$projectsManagement.getMany();
 Create a project.
 
 ```ts
-const project = await mapeo.$projectsManagement.create({...});
+const project = await client.$projectsManagement.create({...});
 ```
 
 **_TODO: What does `opts` look like?_**
@@ -109,9 +109,9 @@ const project = await mapeo.$projectsManagement.create({...});
 Update a project's information. Throws if caller does not have the proper permissions.
 
 ```ts
-const project = await mapeo.$projectsManagement.create({...});
+const project = await client.$projectsManagement.create({...});
 
-const updatedProject = await mapeo.$projectsManagement.update(project.id, {...});
+const updatedProject = await client.$projectsManagement.update(project.id, {...});
 ```
 
 **_TODO: What does `newInfo` look like?_**
@@ -123,9 +123,9 @@ const updatedProject = await mapeo.$projectsManagement.update(project.id, {...})
 Delete a project with the specified `id`. Throws if caller does not have the proper permissions.
 
 ```ts
-const project = await mapeo.$projectsManagement.create();
+const project = await client.$projectsManagement.create();
 
-const deletedProject = await mapeo.$projectsManagement.delete(project.id);
+const deletedProject = await client.$projectsManagement.delete(project.id);
 ```
 
 **_TODO: Does this return a deleted `Project`?_**
@@ -139,9 +139,9 @@ const deletedProject = await mapeo.$projectsManagement.delete(project.id);
 Accept an invite received from another peer.
 
 ```ts
-mapeo.$projectsManagement.on('invite:received', (info) => {
+client.$projectsManagement.on('invite:received', (info) => {
   // In reality, probably would perform logic to check it
-  mapeo.$projectsManagement.invite.accept(info.id, {...})
+  client.$projectsManagement.invite.accept(info.id, {...})
 })
 ```
 
@@ -156,9 +156,9 @@ mapeo.$projectsManagement.on('invite:received', (info) => {
 Decline an invite received from another peer.
 
 ```ts
-mapeo.$projectsManagement.on('invite:received', (info) => {
+client.$projectsManagement.on('invite:received', (info) => {
   // In reality, probably would perform logic to check it
-  mapeo.$projectsManagement.invite.decline(info.id, {...})
+  client.$projectsManagement.invite.decline(info.id, {...})
 })
 ```
 

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -23,10 +23,6 @@
     - [`invite.accept`](#inviteaccept)
     - [`invite.decline`](#invitedecline)
 
-- [Events](#events)
-
-  - [`'invite:received'`](#invitereceived)
-
 ## Description
 
 Exposes an interface for managing projects and responding to project invites.
@@ -167,29 +163,3 @@ mapeo.$projectsManagement.on('invite:received', (info) => {
 ```
 
 **_TODO: What does `params` look like?_**
-
-## Events
-
-### `'invite:received'`
-
-`(info: { id: string, project: Project, invitedBy: ProjectMember, role: ProjectRole }) => void`
-
-Listen to events emitted when a peer invites you to a project.
-
-```ts
-mapeo.$project.on("invite:received", (info) => {
-  const { id, project, invitedBy, role } = info;
-
-  console.log(`Invite id is: ${id}`);
-  console.log(`You are invited to project: ${project.name || project.id}`);
-  console.log(`Invited by: ${invitedBy.id}`);
-  console.log(`If you accept, your role will be: ${role}`);
-
-  // We're adamant about being a coordinator...
-  if (role === "coordinator") {
-    mapeo.$projectsManagement.invite.accept(id, {...});
-  } else {
-    mapeo.$projectsManagement.invite.decline(id, {...});
-  }
-});
-```

--- a/client-docs/projects-management.md
+++ b/client-docs/projects-management.md
@@ -1,0 +1,181 @@
+# Projects Management API
+
+## Table of Contents
+
+- [Description](#description)
+
+- [Types](#types)
+
+  - [`Project`](#project)
+  - [`ProjectRole`](#projectrole)
+  - [`ProjectMember`](#projectmember)
+
+- [Methods](#methods)
+
+  - [`getAll`](#getall)
+  - [`create`](#create)
+  - [`update`](#update)
+  - [`delete`](#delete)
+
+  - [`invite`](#invite)
+
+    - [`invite.accept`](#inviteaccept)
+    - [`invite.decline`](#invitedecline)
+
+- [Events](#events)
+
+  - [`'invite:received'`](#invitereceived)
+
+## Description
+
+Exposes an interface for managing projects and responding to project invites.
+
+## Types
+
+### `Project`
+
+Information about the current project. Could potentially look like:
+
+```ts
+type Project = {
+  id: string;
+  name: string;
+  config: Config;
+};
+```
+
+**_TODO: define `Config`_**
+
+### `ProjectRole`
+
+Information about the project role for a member. Could potentially look like:
+
+```ts
+type ProjectRole = "project-creator" | "coordinator" | "member";
+```
+
+**_TODO: should `non-member` be included here?_**
+
+### `ProjectMember`
+
+A member that is part of the project. Could potentially look like:
+
+```ts
+type ProjectMember = {
+  id: string;
+  name?: string;
+  role: ProjectRole;
+};
+```
+
+## Methods
+
+### `getAll`
+
+`() => Promise<Project[]>`
+
+Get all projects.
+
+```ts
+const projects = await mapeo.$projectsManagement.getAll();
+```
+
+### `create`
+
+`(opts?: {}) => Promise<Project>`
+
+Create a project.
+
+```ts
+const project = await mapeo.$projectsManagement.create({...});
+```
+
+**_TODO: What does `opts` look like?_**
+
+### `update`
+
+`(projectId: string, newInfo: {}) => Promise<Project>`
+
+Update a project's information. Throws if caller does not have the proper permissions.
+
+```ts
+const project = await mapeo.$projectsManagement.create({...});
+
+const updatedProject = await mapeo.$projectsManagement.update(project.id, {...});
+```
+
+**_TODO: What does `newInfo` look like?_**
+
+### `delete`
+
+`(id: string) => Promise<Project>`
+
+Delete a project with the specified `id`. Throws if caller does not have the proper permissions.
+
+```ts
+const project = await mapeo.$projectsManagement.create();
+
+const deletedProject = await mapeo.$projectsManagement.delete(project.id);
+```
+
+**_TODO: Does this return a deleted `Project`?_**
+
+### `invite`
+
+#### `invite.accept`
+
+`(id: string, params: {}) => Promise<void>`
+
+Accept an invite received from another peer.
+
+```ts
+mapeo.$projectsManagement.on('invite:received', (info) => {
+  // In reality, probably would perform logic to check it
+  mapeo.$projectsManagement.invite.accept(info.id, {...})
+})
+```
+
+**_TODO: What does `params` look like?_**
+
+**_TODO: Does this belong in this API?_**
+
+#### `invite.decline`
+
+`(id: string, params: {}) => Promise<void>`
+
+Decline an invite received from another peer.
+
+```ts
+mapeo.$projectsManagement.on('invite:received', (info) => {
+  // In reality, probably would perform logic to check it
+  mapeo.$projectsManagement.invite.decline(info.id, {...})
+})
+```
+
+**_TODO: What does `params` look like?_**
+
+## Events
+
+### `'invite:received'`
+
+`(info: { id: string, project: Project, invitedBy: ProjectMember, role: ProjectRole }) => void`
+
+Listen to events emitted when a peer invites you to a project.
+
+```ts
+mapeo.$project.on("invite:received", (info) => {
+  const { id, project, invitedBy, role } = info;
+
+  console.log(`Invite id is: ${id}`);
+  console.log(`You are invited to project: ${project.name || project.id}`);
+  console.log(`Invited by: ${invitedBy.id}`);
+  console.log(`If you accept, your role will be: ${role}`);
+
+  // We're adamant about being a coordinator...
+  if (role === "coordinator") {
+    mapeo.$projectsManagement.invite.accept(id, {...});
+  } else {
+    mapeo.$projectsManagement.invite.decline(id, {...});
+  }
+});
+```


### PR DESCRIPTION
Relevant issues:

- https://github.com/digidem/mapeo-core-next/issues/74
- https://github.com/digidem/mapeo-core-next/issues/106

TODOs:

- Consider removing `$` prefix for namespace
- Nesting for `invite` okay?
- API kind of assumes support for multiproject at some point. Okay to keep that design?
- ~remove events spec~