### PR TITLE
add docs about events reference for core client api

### DIFF
--- a/client-docs/events.md
+++ b/client-docs/events.md
@@ -1,0 +1,201 @@
+# Events Reference
+
+## Description
+
+Consolidated list of events that are emitted from the server and can be subscribed to from the server or client.
+
+## Table of Contents
+
+- [`'device:connect'`](#deviceconnect)
+- [`'device:disconnect'`](#devicedisconnect)
+- [`'device:info'`](#deviceinfo)
+- [`'device:sync'`](#sync)
+- [`'discovery:start'`](#discoverystart)
+- [`'discovery:stop'`](#discoverystop)
+- [`'sync:start'`](#syncstart)
+- [`'sync:stop'`](#syncstop)
+- [`'invite:received'`](#invitereceived)
+- [`'invite:accepted'`](#inviteaccepted)
+- [`'invite:declined'`](#invitedeclined)
+
+---
+
+### `'device:connect'`
+
+`(info: DeviceInfo) => void`
+
+Emits when a peer connects.
+
+```ts
+mapeo.on("device:connect", (info: DeviceInfo) => {
+  console.log(`Device with id ${info.id} connected`);
+});
+```
+
+**_TODO: Should the payload include more than just `DeviceInfo`?_**
+
+### `'device:disconnect'`
+
+`(info: DeviceInfo) => void`
+
+Emits when a peer disconnects.
+
+```ts
+mapeo.on("device:disconnect", (info: DeviceInfo) => {
+  console.log(`Device with id ${info.id} disconnected`);
+});
+```
+
+**_TODO: Should the payload include more than just `DeviceInfo`?_**
+
+### `'device:info'`
+
+`(info: DeviceInfo) => void`
+
+Emits when information about a peer changes.
+
+```ts
+mapeo.on("device:info", (info: DeviceInfo) => {
+  // Use updated device information in some way...
+});
+```
+
+**_TODO: Improve description_**
+
+**_TODO: Improve usage example_**
+
+### `'device:sync'`
+
+`(state: SyncState) => void`
+
+Emits when ongoing sync is occurring with a peer.
+
+```ts
+mapeo.on("device:sync", (state: SyncState) => {
+  // Check for sync errors
+  if (state.syncError) {
+    // Handle sync error...
+    return;
+  }
+  // Check for connection errors
+  if (state.connectionError) {
+    // Handle connection error...
+    return;
+  }
+  let gaveEverything = false;
+  let receivedEverything = false;
+  // They have given everything that we wanted
+  if (state.db.has === 0 && state.media.has === 0) {
+    gaveEverything = true;
+  }
+  // They have received everything that they wanted
+  if (state.db.want === 0 && state.media.want === 0) {
+    receivedEverything = true;
+  }
+  if (gaveEverything && receivedEverything) {
+    console.log("Sync basically done!");
+  }
+});
+```
+
+**_TODO: Should there be a separate event for when sync is done?_**
+
+### `'discovery:start'`
+
+`() => void`
+
+Emits when discovery is enabled.
+
+```ts
+mapeo.on("discovery:start", () => {
+  console.log("Now seeking new peers");
+});
+```
+
+### `'discovery:stop'`
+
+`() => void`
+
+Emits when discovery is disabled.
+
+```ts
+mapeo.on("discovery:stop", () => {
+  console.log("No longer seeking new peers");
+});
+```
+
+### `'sync:start'`
+
+`() => void`
+
+Emits when sync is enabled.
+
+```ts
+mapeo.on("sync:start", () => {
+  console.log("Now allowing sync");
+});
+```
+
+### `'sync:stop'`
+
+`() => void`
+
+Emits when sync is disabled.
+
+```ts
+mapeo.on("sync:stop", () => {
+  console.log("No longer allowing sync");
+});
+```
+
+### `'invite:received'`
+
+`(info: { id: string, project: Project, invitedBy: ProjectMember, role: ProjectRole }) => void`
+
+Listen to events emitted when a peer invites you to a project.
+
+```ts
+mapeo.on("invite:received", (info) => {
+  const { id, project, invitedBy, role } = info;
+  console.log(`Invite id is: ${id}`);
+  console.log(`You are invited to project: ${project.name || project.id}`);
+  console.log(`Invited by: ${invitedBy.id}`);
+  console.log(`If you accept, your role will be: ${role}`);
+  // We're adamant about being a coordinator...
+  if (role === "coordinator") {
+    mapeo.$projectsManagement.invite.accept(id, {...});
+  } else {
+    mapeo.$projectsManagement.invite.decline(id, {...});
+  }
+});
+```
+
+### `'invite:accepted'`
+
+`(id: string, info: { role: ProjectRole }) => void`
+
+Emits when an invited peer has accepted an invitation to join the project. `info` represents information about the invitation that was sent, such as the role.
+
+```ts
+mapeo.on("invite:accepted", async (id, info) => {
+  console.log(`${id} accepted invite to be ${info.role}`);
+  // Should be able to retrieve the project member now
+  const member = await mapeo.$project.member.get(id);
+});
+```
+
+**_TODO: should it be possible to get the member at this point, or should this be responsible for explicitly adding the member to the project? i.e. calling `addMember` in the callback body?_**
+
+### `'invite:declined'`
+
+`(id: string, info: { role: ProjectRole }) => void`
+
+Listen to events that are emitted when an invited peer has declined an invitation to join the project. `info` represents information about the invitation that was sent, such as the role.
+
+```ts
+mapeo.on("invite:declined", (id, info) => {
+  console.log(`${id} declined invite to be ${info.role}`);
+});
+```
+
+**_TODO: what other things should be included in `info`?_**

--- a/client-docs/events.md
+++ b/client-docs/events.md
@@ -11,6 +11,8 @@ Consolidated list of events that are emitted from the server and can be subscrib
   - [`Peer`](#peer)
   - [`SyncExchangeInfo`](#syncexchangeinfo)
   - [`SyncState`](#syncstate)
+  - [`ProjectRole`](#projectrole)
+  - [`Invite`](#invite)
 
 - [Events](#events)
   - [`'peer-connect'`](#peer-connect)
@@ -86,9 +88,17 @@ type SyncState = {
 };
 ```
 
-### `InviteInfo`
+### `ProjectRole`
 
-Information about an invite that has been sent, received, accepted, or declined.
+Information about the project role for a member.
+
+```ts
+type ProjectRole = "creator" | "coordinator" | "member";
+```
+
+### `Invite`
+
+Information about an invite that has been received, accepted, or declined.
 
 ```ts
 type Invite = {
@@ -238,7 +248,7 @@ client.on("sync-stop", () => {
 
 ### `'invite-received'`
 
-`(invite: InviteInfo) => void`
+`(invite: Invite) => void`
 
 Listen to events emitted when a peer invites you to a project. `invite.from` represents information about the peer that sent the invite.
 
@@ -260,13 +270,13 @@ client.on("invite-received", (invite) => {
 
 ### `'invite-accepted'`
 
-`(info: InviteInfo) => void`
+`(invite: Invite) => void`
 
-Emits when an invited peer has accepted an invitation to join the project. `info.from` field represents information about the peer that accepted the invite.
+Emits when an invited peer has accepted an invitation to join the project. `invite.from` field represents information about the peer that accepted the invite.
 
 ```ts
-client.on("invite-accepted", (info) => {
-  console.log(`${info.id} accepted invite to be ${info.role}`);
+client.on("invite-accepted", (invite) => {
+  console.log(`${invite.id} accepted invite to be ${info.role}`);
 });
 ```
 
@@ -274,12 +284,12 @@ client.on("invite-accepted", (info) => {
 
 ### `'invite-declined'`
 
-`(info: InviteInfo) => void`
+`(invite: Invite) => void`
 
 Listen to events that are emitted when an invited peer has declined an invitation to join the project. `info.from` represents information about the peer that declined the invite.
 
 ```ts
-client.on("invite-declined", (info) => {
-  console.log(`${info.id} declined invite to be ${info.role}`);
+client.on("invite-declined", (invite) => {
+  console.log(`${invite.id} declined invite to be ${invite.role}`);
 });
 ```

--- a/client-docs/events.md
+++ b/client-docs/events.md
@@ -114,7 +114,7 @@ type Invite = {
 Emits when a peer connects.
 
 ```ts
-mapeo.on("peer-connect", (peer) => {
+client.on("peer-connect", (peer) => {
   console.log(`Peer with id ${peer.id} connected`);
 });
 ```
@@ -126,7 +126,7 @@ mapeo.on("peer-connect", (peer) => {
 Emits when a peer disconnects.
 
 ```ts
-mapeo.on("peer-disconnect", (peer) => {
+client.on("peer-disconnect", (peer) => {
   console.log(`Device with id ${peer.id} disconnected`);
 });
 ```
@@ -138,7 +138,7 @@ mapeo.on("peer-disconnect", (peer) => {
 Emits when information about a peer changes.
 
 ```ts
-mapeo.on("peer-info", (peer) => {
+client.on("peer-info", (peer) => {
   // Use updated peer in some way...
 });
 ```
@@ -154,7 +154,7 @@ mapeo.on("peer-info", (peer) => {
 Emits when ongoing sync is occurring with a peer.
 
 ```ts
-mapeo.on("peer-sync", (state) => {
+client.on("peer-sync", (state) => {
   // Check for sync errors
   if (state.syncError) {
     // Handle sync error...
@@ -195,7 +195,7 @@ mapeo.on("peer-sync", (state) => {
 Emits when discovery is enabled.
 
 ```ts
-mapeo.on("discovery-start", () => {
+client.on("discovery-start", () => {
   console.log("Now seeking new peers");
 });
 ```
@@ -207,7 +207,7 @@ mapeo.on("discovery-start", () => {
 Emits when discovery is disabled.
 
 ```ts
-mapeo.on("discovery-stop", () => {
+client.on("discovery-stop", () => {
   console.log("No longer seeking new peers");
 });
 ```
@@ -219,7 +219,7 @@ mapeo.on("discovery-stop", () => {
 Emits when sync is enabled.
 
 ```ts
-mapeo.on("sync-start", () => {
+client.on("sync-start", () => {
   console.log("Now allowing sync");
 });
 ```
@@ -231,7 +231,7 @@ mapeo.on("sync-start", () => {
 Emits when sync is disabled.
 
 ```ts
-mapeo.on("sync-stop", () => {
+client.on("sync-stop", () => {
   console.log("No longer allowing sync");
 });
 ```
@@ -243,7 +243,7 @@ mapeo.on("sync-stop", () => {
 Listen to events emitted when a peer invites you to a project. `invite.from` represents information about the peer that sent the invite.
 
 ```ts
-mapeo.on("invite-received", (invite) => {
+client.on("invite-received", (invite) => {
   console.log(`Invite id is: ${invite.id}`);
   console.log(`You are invited to project: ${invite.project.name || invite.project.id}`);
   console.log(`Invited by: ${invite.from.id}`);
@@ -251,9 +251,9 @@ mapeo.on("invite-received", (invite) => {
 
   // We're adamant about being a coordinator...
   if (invite.role === "coordinator") {
-    mapeo.$projectsManagement.invite.accept(invite.id, {...});
+    client.$projectsManagement.invite.accept(invite.id, {...});
   } else {
-    mapeo.$projectsManagement.invite.decline(invite.id, {...});
+    client.$projectsManagement.invite.decline(invite.id, {...});
   }
 });
 ```
@@ -265,7 +265,7 @@ mapeo.on("invite-received", (invite) => {
 Emits when an invited peer has accepted an invitation to join the project. `info.from` field represents information about the peer that accepted the invite.
 
 ```ts
-mapeo.on("invite-accepted", (info) => {
+client.on("invite-accepted", (info) => {
   console.log(`${info.id} accepted invite to be ${info.role}`);
 });
 ```
@@ -279,7 +279,7 @@ mapeo.on("invite-accepted", (info) => {
 Listen to events that are emitted when an invited peer has declined an invitation to join the project. `info.from` represents information about the peer that declined the invite.
 
 ```ts
-mapeo.on("invite-declined", (info) => {
+client.on("invite-declined", (info) => {
   console.log(`${info.id} declined invite to be ${info.role}`);
 });
 ```

--- a/client-docs/events.md
+++ b/client-docs/events.md
@@ -9,7 +9,7 @@ Consolidated list of events that are emitted from the server and can be subscrib
 - [`'device:connect'`](#deviceconnect)
 - [`'device:disconnect'`](#devicedisconnect)
 - [`'device:info'`](#deviceinfo)
-- [`'device:sync'`](#sync)
+- [`'device:sync'`](#devicesync)
 - [`'discovery:start'`](#discoverystart)
 - [`'discovery:stop'`](#discoverystop)
 - [`'sync:start'`](#syncstart)


### PR DESCRIPTION
playing around with rpc-reflector and realizing that it doesn't play too nicely with getter methods that return event emitters, so each namespace having an EventEmitter interface probably isn't the best approach.

Instead, we'll define the overarching client as the event emitter and have properly scoped event names. For example, `mapeo.$project.on("invite-accepted", () => {...})` becomes `mapeo.on('invite-accepted', () => {...})`

i won't update the other PRs just yet until I get some feedback regarding events, but suspecting that what's specified here will be the approach we take.

TODOs:

- ~should the `device:` prefix be changed to `peer:`?~
- ~use hypen as delimiter~